### PR TITLE
Added clip removal

### DIFF
--- a/Ensemble of One/css/editor-menu.css
+++ b/Ensemble of One/css/editor-menu.css
@@ -94,8 +94,9 @@
 
 .editor-menu__command {
     background-color: #fff;
-    border: 1px solid #d3d3d3;
-    border-left: 10px solid #d3d3d3;
+    border: 1px solid #7e7e7e;
+    border-left: 10px solid #7e7e7e;
+    color: #333;
     font-size: 24px;
     margin: 0 0 10px 0;
     line-height: 40px;
@@ -114,6 +115,7 @@
     pointer-events: none;
     touch-action: none;
     color: #999;
+    border-color: #d3d3d3
 }
 
 .editor-menu__divider {

--- a/Ensemble of One/js/editor/menumgr.js
+++ b/Ensemble of One/js/editor/menumgr.js
@@ -63,8 +63,9 @@
             if (Ensemble.HistoryMGR.canUndo()) $(".editor-command__undo").removeClass("editor-command--disabled");
             if (Ensemble.HistoryMGR.canRedo()) $(".editor-command__redo").removeClass("editor-command--disabled");
 
-            if (this.currentState == this.menuState.clipSelected) {
-
+            if (Ensemble.Editor.SelectionMGR.selected.length > 0) {
+                $(".editor-command__remove-clip").removeClass("editor-command--disabled");
+                $(".editor-command__clear-selection").removeClass("editor-command--disabled");
             }
         },
 
@@ -146,6 +147,16 @@
                 if (command == "undo") setTimeout(function () { Ensemble.HistoryMGR.undoLast() }, 0);
                 else if (command == "redo") setTimeout(function () { Ensemble.HistoryMGR.redoNext() }, 0);
                 else if (command == "exit") setTimeout(function () { Ensemble.Pages.Editor.unload() }, 0);
+
+                else if (command == "remove-clip") {
+                    let removeAction = new Ensemble.Events.Action(Ensemble.Events.Action.ActionType.removeClip, {
+                        clipIds: Ensemble.Editor.SelectionMGR.selected
+                    });
+                    Ensemble.Editor.SelectionMGR.clearSelection();
+                    Ensemble.Editor.SelectionMGR.clearHovering();
+                    Ensemble.HistoryMGR.performAction(removeAction);
+                }
+                else if (command == "clear-selection") setTimeout(function () { Ensemble.Editor.SelectionMGR.clearSelection() }, 0);
 
                 Ensemble.Editor.MenuMGR.closeMenu();
             },

--- a/Ensemble of One/js/fileio.js
+++ b/Ensemble of One/js/fileio.js
@@ -78,42 +78,55 @@
             if (Ensemble.HistoryMGR.canUndo()) {
                 for (var i = 0; i < Ensemble.HistoryMGR._backStack.length; i++) {
                     xml.BeginNode("HistoryAction");
-                    switch (Ensemble.HistoryMGR._backStack[i]._type) {
-                        case Ensemble.Events.Action.ActionType.createTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());                            
-                            break;
-                        case Ensemble.Events.Action.ActionType.renameTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());                            
-                            xml.Attrib("oldName", Ensemble.HistoryMGR._backStack[i]._payload.oldName);
-                            xml.Attrib("newName", Ensemble.HistoryMGR._backStack[i]._payload.newName);
-                            break;
-                        case Ensemble.Events.Action.ActionType.trackVolumeChanged:
-                            xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());                            
-                            xml.Attrib("oldVolume", Ensemble.HistoryMGR._backStack[i]._payload.oldVolume.toString());
-                            xml.Attrib("newVolume", Ensemble.HistoryMGR._backStack[i]._payload.newVolume.toString());
-                            break;
-                        case Ensemble.Events.Action.ActionType.moveTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());                            
-                            xml.Attrib("origin", Ensemble.HistoryMGR._backStack[i]._payload.origin.toString());
-                            xml.Attrib("destination", Ensemble.HistoryMGR._backStack[i]._payload.destination.toString());
-                            break;
-                        case Ensemble.Events.Action.ActionType.removeTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());                            
-                            xml.Attrib("originalLocation", Ensemble.HistoryMGR._backStack[i]._payload.originalLocation.toString())
-                            xml = Ensemble.FileIO._writeTrackToXML(xml, Ensemble.HistoryMGR._backStack[i]._payload.trackObj);
-                            break;
-                        case Ensemble.Events.Action.ActionType.importClip:
-                            xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
-                            xml.Attrib("clipId", Ensemble.HistoryMGR._backStack[i]._payload.clipId.toString());
-                            break;
-                        default:
-                            console.error("Unable to save History Action to disk - unknown type.");
+                    if (Ensemble.HistoryMGR._backStack[i]._type == Ensemble.Events.Action.ActionType.createTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());
                     }
+
+                    else if (Ensemble.HistoryMGR._backStack[i]._type == Ensemble.Events.Action.ActionType.renameTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());
+                        xml.Attrib("oldName", Ensemble.HistoryMGR._backStack[i]._payload.oldName);
+                        xml.Attrib("newName", Ensemble.HistoryMGR._backStack[i]._payload.newName);
+                    }
+
+                    else if (Ensemble.HistoryMGR._backStack[i]._type == Ensemble.Events.Action.ActionType.trackVolumeChanged) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());
+                        xml.Attrib("oldVolume", Ensemble.HistoryMGR._backStack[i]._payload.oldVolume.toString());
+                        xml.Attrib("newVolume", Ensemble.HistoryMGR._backStack[i]._payload.newVolume.toString());
+                    }
+
+                    else if (Ensemble.HistoryMGR._backStack[i]._type == Ensemble.Events.Action.ActionType.moveTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());
+                        xml.Attrib("origin", Ensemble.HistoryMGR._backStack[i]._payload.origin.toString());
+                        xml.Attrib("destination", Ensemble.HistoryMGR._backStack[i]._payload.destination.toString());
+                    }
+
+                    else if (Ensemble.HistoryMGR._backStack[i]._type == Ensemble.Events.Action.ActionType.removeTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackId.toString());
+                        xml.Attrib("originalLocation", Ensemble.HistoryMGR._backStack[i]._payload.originalLocation.toString())
+                        xml = Ensemble.FileIO._writeTrackToXML(xml, Ensemble.HistoryMGR._backStack[i]._payload.trackObj);
+                    }
+
+                    else if (Ensemble.HistoryMGR._backStack[i]._type == Ensemble.Events.Action.ActionType.importClip) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
+                        xml.Attrib("clipId", Ensemble.HistoryMGR._backStack[i]._payload.clipId.toString());
+                    }
+
+                    else if (Ensemble.HistoryMGR._backStack[i]._type == Ensemble.Events.Action.ActionType.removeClip) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._backStack[i]._type);
+                        for (let k = 0; k < Ensemble.HistoryMGR._backStack[i]._payload.clipObjs.length; k++) {
+                            xml.BeginNode("RemovedClip");
+                            xml.Attrib("trackId", Ensemble.HistoryMGR._backStack[i]._payload.trackLocations[k].toString());
+                            xml = Ensemble.FileIO._writeClipToXML(xml, Ensemble.HistoryMGR._backStack[i]._payload.clipObjs[k]);
+                            xml.EndNode();
+                        }
+                    }
+
+                    else console.error("Unable to save History Action to disk - unknown type.");
                     xml.EndNode();
                 }
             }
@@ -124,42 +137,54 @@
             if (Ensemble.HistoryMGR.canRedo()) {
                 for (var i = 0; i < Ensemble.HistoryMGR._forwardStack.length; i++) {
                     xml.BeginNode("HistoryAction");
-                    switch (Ensemble.HistoryMGR._forwardStack[i]._type) {
-                        case Ensemble.Events.Action.ActionType.createTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());                            
-                            break;
-                        case Ensemble.Events.Action.ActionType.renameTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());                            
-                            xml.Attrib("oldName", Ensemble.HistoryMGR._forwardStack[i]._payload.oldName);
-                            xml.Attrib("newName", Ensemble.HistoryMGR._forwardStack[i]._payload.newName);
-                            break;
-                        case Ensemble.Events.Action.ActionType.trackVolumeChanged:
-                            xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());                            
-                            xml.Attrib("oldVolume", Ensemble.HistoryMGR._forwardStack[i]._payload.oldVolume.toString());
-                            xml.Attrib("newVolume", Ensemble.HistoryMGR._forwardStack[i]._payload.newVolume.toString());
-                            break;
-                        case Ensemble.Events.Action.ActionType.moveTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());                            
-                            xml.Attrib("origin", Ensemble.HistoryMGR._forwardStack[i]._payload.origin.toString());
-                            xml.Attrib("destination", Ensemble.HistoryMGR._forwardStack[i]._payload.destination.toString());
-                            break;
-                        case Ensemble.Events.Action.ActionType.removeTrack:
-                            xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
-                            xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());                            
-                            //xml.Attrib("originalLocation", Ensemble.HistoryMGR._forwardStack[i]._payload.originalLocation.toString())
-                            //xml = Ensemble.FileIO._writeTrackToXML(xml, Ensemble.HistoryMGR._forwardStack[i]._payload.trackObj);
-                            break;
-                        case Ensemble.Events.Action.ActionType.importClip:
-                            xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
-                            xml.Attrib("destinationTrack", Ensemble.HistoryMGR._forwardStack[i]._payload.destinationTrack.toString());
-                            xml = Ensemble.FileIO._writeClipToXML(xml, Ensemble.HistoryMGR._forwardStack[i]._payload.clipObj);
-                            break;
-                        default:
-                            console.error("Unable to save History Action to disk - unknown type.");
+                    if (Ensemble.HistoryMGR._forwardStack[i]._type == Ensemble.Events.Action.ActionType.createTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());
+                    }
+
+                    else if (Ensemble.HistoryMGR._forwardStack[i]._type == Ensemble.Events.Action.ActionType.renameTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());
+                        xml.Attrib("oldName", Ensemble.HistoryMGR._forwardStack[i]._payload.oldName);
+                        xml.Attrib("newName", Ensemble.HistoryMGR._forwardStack[i]._payload.newName);
+                    }
+
+                    else if (Ensemble.HistoryMGR._forwardStack[i]._type == Ensemble.Events.Action.ActionType.trackVolumeChanged) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());
+                        xml.Attrib("oldVolume", Ensemble.HistoryMGR._forwardStack[i]._payload.oldVolume.toString());
+                        xml.Attrib("newVolume", Ensemble.HistoryMGR._forwardStack[i]._payload.newVolume.toString());
+                    }
+
+                    else if (Ensemble.HistoryMGR._forwardStack[i]._type == Ensemble.Events.Action.ActionType.moveTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());
+                        xml.Attrib("origin", Ensemble.HistoryMGR._forwardStack[i]._payload.origin.toString());
+                        xml.Attrib("destination", Ensemble.HistoryMGR._forwardStack[i]._payload.destination.toString());
+                    }
+
+                    else if (Ensemble.HistoryMGR._forwardStack[i]._type == Ensemble.Events.Action.ActionType.removeTrack) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
+                        xml.Attrib("trackId", Ensemble.HistoryMGR._forwardStack[i]._payload.trackId.toString());
+                    }
+
+                    else if (Ensemble.HistoryMGR._forwardStack[i]._type == Ensemble.Events.Action.ActionType.importClip) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
+                        xml.Attrib("destinationTrack", Ensemble.HistoryMGR._forwardStack[i]._payload.destinationTrack.toString());
+                        xml = Ensemble.FileIO._writeClipToXML(xml, Ensemble.HistoryMGR._forwardStack[i]._payload.clipObj);
+                    }
+
+                    else if (Ensemble.HistoryMGR._forwardStack[i]._type == Ensemble.Events.Action.ActionType.removeClip) {
+                        xml.Attrib("type", Ensemble.HistoryMGR._forwardStack[i]._type);
+                        for (let k = 0; k < Ensemble.HistoryMGR._forwardStack[i]._payload.clipIds.length; k++) {
+                            xml.BeginNode("RemovedClip");
+                            xml.Attrib("clipId", Ensemble.HistoryMGR._forwardStack[i]._payload.clipIds[k].toString());
+                            xml.EndNode();
+                        }
+                    }
+
+                    else {
+                        console.error("Unable to save History Action to disk - unknown type.");
                     }
                     xml.EndNode();
                 }
@@ -445,6 +470,19 @@
                             }
                         ));
                     }
+                    else if (actionType === Ensemble.Events.Action.ActionType.removeClip) {
+                        let removedClips = undoActions[i].getElementsByTagName("RemovedClip");
+                        let removedArr = [];
+                        let trackArr = [];
+                        for (let k = 0; k < removedClips.length; k++) {
+                            removedArr.push(Ensemble.FileIO._loadClipFromXML(removedClips[k].getElementsByTagName("Clip")[0]));
+                            trackArr.push(parseInt(removedClips[k].getAttribute("trackId"), 10));
+                        }
+                        Ensemble.HistoryMGR._backStack.push(new Ensemble.Events.Action(Ensemble.Events.Action.ActionType.removeClip, {
+                            clipObjs: removedArr,
+                            trackLocations: trackArr
+                        }));
+                    }
                     else {
                         console.error("Unable to load History Action from disk - unknown type.");
                     }
@@ -510,6 +548,16 @@
                                 destinationTime: generatedClip.startTime
                             }
                         ));
+                    }
+                    else if (actionType === Ensemble.Events.Action.ActionType.removeClip) {
+                        let removedClips = redoActions[i].getElementsByTagName("RemovedClip");
+                        let removedArr = [];
+                        for (let k = 0; k < removedClips.length; k++) {
+                            removedArr.push(parseInt(removedClips[k].getAttribute("clipId"), 10));
+                        }
+                        Ensemble.HistoryMGR._forwardStack.push(new Ensemble.Events.Action(Ensemble.Events.Action.ActionType.removeClip, {
+                            clipIds: removedArr,
+                        }));
                     }
                     else {
                         console.error("Unable to load History Action from disk - unknown type.");

--- a/Ensemble of One/js/historymgr.js
+++ b/Ensemble of One/js/historymgr.js
@@ -50,6 +50,13 @@
             setTimeout(function () { Ensemble.FileIO.saveProject(); }, 0);
         },
 
+        _undoRemoveClipComplete: function (loadedClips) {
+            Ensemble.HistoryMGR._pendingAction.finishUndo(loadedClips);
+            Ensemble.HistoryMGR._forwardStack.push(Ensemble.HistoryMGR._pendingAction);
+            Ensemble.HistoryMGR._pendingAction = null;
+            setTimeout(function () { Ensemble.FileIO.saveProject(); }, 0);
+        },
+
         undoLast: function () {
             if (Ensemble.HistoryMGR._backStack.length > 0) {
                 var actionToUndo = Ensemble.HistoryMGR._backStack.pop();
@@ -104,6 +111,14 @@
                 document.getElementById("editor-history-msg").innerText = this._backStack[this._backStack.length - 1].getMessage();
             }
             else document.getElementById("editor-history-msg").innerText = "No recent history. Start editing!";
+        },
+
+        unload: function () {
+            /// <summary>Resets the HistoryMGR back to its original state.</summary>
+            this._forwardStack = [];
+            this._backStack = [];
+            this._pendingAction = null;
+            this._pendingCallback = null;
         }
     });
 })();

--- a/Ensemble of One/js/pages/editor.js
+++ b/Ensemble of One/js/pages/editor.js
@@ -87,6 +87,7 @@
                 Ensemble.Editor.PlaybackMGR.unload();
                 Ensemble.Editor.Renderer.unload();
                 Ensemble.Editor.MenuMGR.unload();
+                Ensemble.HistoryMGR.unload();
 
                 window.setTimeout(function () {
                     $("#imgMainLogo").css("display", "initial");
@@ -182,13 +183,6 @@
             /// <summary>Refreshes the Media Browser at its current location</summary>
             console.log("Refreshing the Media Browser...");
             Ensemble.MediaBrowser.navigateToFolder(Ensemble.MediaBrowser.currentLocation());
-        },
-
-        unloadProject: function () {
-            //Unloads the current project.
-            Ensemble.Editor.TimelineMGR.unload();
-            Ensemble.Editor.PlaybackMGR.unload();
-            Ensemble.Editor.Renderer.unload();
         },
 
         //// PRIVATE METHODS ////


### PR DESCRIPTION
Changes include:
-Added the ability to remove clips from a project. Removing a clip is
fully History-capable.
-Replaced switch statements with if/else statements in
Ensemble.Events.Action and Ensemble.FileIO due to VS IntelliSense
stability issues.
-Fixed a bug that resulted in a corrupt HistoryMGR after closing a
project and attempting to open another one (the previous project's
history was erroneously kept in memory past project closure).
-Removed Ensemble.Pages.Editor.unloadProject() (the method was a
carry-over from an older version of the page navigation/menu system).
-Made the Editor menu commands a little more obvious when enabled or
disabled.
