### PR TITLE
Added clip drag and drop between tracks

### DIFF
--- a/Ensemble of One/css/timeline.css
+++ b/Ensemble of One/css/timeline.css
@@ -171,6 +171,6 @@
     color: #fff;
 }
 
-.callout-command--move-clip {
+.callout-command--move-clip, .callout-command--move-track-clip {
     cursor: pointer;
 }

--- a/Ensemble of One/default.html
+++ b/Ensemble of One/default.html
@@ -308,8 +308,7 @@
 
             <div class="editorTimelineDragPreviewFlyout" tabindex="-1">00:00:00.000</div>
             <div class="timeline-selection-callout" tabindex="-1">
-                <div class="selection-callout__command callout-command--customizable callout-command--split-clip" data-callout-command="split-clip">&#xE129;</div>
-                <div class="selection-callout__command callout-command--customizable callout-command--trim-clip" data-callout-command="trim-clip">&#xE12C;</div>
+                <div class="selection-callout__command callout-command--move-track-clip" data-callout-command="move-track-clip">&#xE174;</div>
                 <div class="selection-callout__command callout-command--move-clip" data-callout-command="move-clip">&#xE13C;</div>
                 <div class="selection-callout__command callout-command--context-menu" data-callout-command="context-menu">&#xE10C;</div>
             </div>


### PR DESCRIPTION
Changes include:
- Added vertical movement button to clip selection callout. Clips can
  now be dragged from one track into another.
- In the case of an an unresolved single-move clip collision, the user
  is presented an OS dialog with commands to move the clip before or after
  the offending clip (or cancel the move altogether).
