### PR TITLE
Added direct drag and drop between Timeline tracks

### DIFF
--- a/Ensemble of One/css/timeline.css
+++ b/Ensemble of One/css/timeline.css
@@ -103,6 +103,16 @@
     background-color: rgba(255, 255, 255, 0.8);
     font-size: 24px;
     font-weight: bold;
+    animation: timelineGhostEnter 0.2s ease;
+}
+
+@keyframes timelineGhostEnter {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
 }
 
 .timeline-clip-ghost:after {


### PR DESCRIPTION
Changes include:
- Mouse users can now drag and drop clips between tracks by clicking and
  holding directly on the clip.
- Added entrance animation (quick fade) to timeline clip ghosts.
