### PR TITLE
Audio support, Timeline enhancements, bug fixes

### DIFF
--- a/Ensemble of One/css/timeline.css
+++ b/Ensemble of One/css/timeline.css
@@ -92,6 +92,7 @@
     left: 0;
     top: 0;
     height: 100%;
+    cursor: text;
 }
 
 .timeline-ruler__flag {

--- a/Ensemble of One/js/editor/clip.js
+++ b/Ensemble of One/js/editor/clip.js
@@ -247,6 +247,13 @@
                 return returnVal;
             },
 
+            isRenderable: function () {
+                /// <summary>Returns whether or not the clip can be drawn to the screen (i.e., is either a video or image file).</summary>
+                /// <returns type="Boolean">Whether or not the clip is renderable.</returns>
+                if (this.type == Ensemble.Editor.Clip.ClipType.video || this.type == Ensemble.Editor.Clip.ClipType.picture) return true;
+                return false;
+            },
+
             unload: function () {
                 /// <summary>Unloads the clip and turns its file reference into a stub.</summary>
                 let domPlayer = document.getElementById(this._player.id);

--- a/Ensemble of One/js/editor/playbackmgr.js
+++ b/Ensemble of One/js/editor/playbackmgr.js
@@ -35,11 +35,16 @@
 
         play: function () {
             /// <summary>Begins playback from the current position in the project.</summary>
+            let playbackList = Ensemble.Editor.TimelineMGR._clipIndex[Ensemble.Editor.TimelineMGR._clipIndexPosition].playbackList,
+                clipCount = playbackList.length;
+
             this.playing = true;
             this._timer.postMessage({ type: "startTimer" });
-            for (let i = 0; i < Ensemble.Editor.TimelineMGR._clipIndex[Ensemble.Editor.TimelineMGR._clipIndexPosition].renderList.length; i++) {
-                Ensemble.Editor.TimelineMGR._clipIndex[Ensemble.Editor.TimelineMGR._clipIndexPosition].renderList[i].play();
+
+            for (let i = 0; i < clipCount; i++) {
+                playbackList[i].play();
             }
+
             Ensemble.Editor.Renderer.start();
             this.ui.buttonPlayPause.innerHTML = "&#xE103;";
         },
@@ -142,10 +147,8 @@
                 Ensemble.Editor.PlaybackMGR._clipSeekCount++;
                 if (Ensemble.Editor.PlaybackMGR._clipSeekCount == Ensemble.Session.projectClipCount) {
                     console.log("Finished seeking.");
-                    //setTimeout(function () { Ensemble.Editor.Renderer.renderSingleFrame(); }, 0);
                     Ensemble.Editor.PlaybackMGR._renderNextTimeUpdate = true;
                     Ensemble.Editor.PlaybackMGR._timer.postMessage({ type: "seeked", contents: Ensemble.Editor.PlaybackMGR._seekDestination });
-                    setTimeout(function () { Ensemble.Editor.Renderer.renderSingleFrame() }, 0);
                 }
             }
         }

--- a/Ensemble of One/js/editor/selectionmgr.js
+++ b/Ensemble of One/js/editor/selectionmgr.js
@@ -36,15 +36,17 @@
                     found = true;
                 }
                 if (this.selected[i] != clipId) {
-                    Ensemble.Editor.TimelineMGR.getClipById(this.selected[i]).selected = false;
+                    let targetClip = Ensemble.Editor.TimelineMGR.getClipById(this.selected[i]);
+                    targetClip.selected = false;
                     $("#" + Ensemble.Editor.TimelineMGR._buildClipDOMId(this.selected[i])).removeClass("timeline-clip--selected");
-                    needFrame = true;
+                    if (targetClip.isRenderable() && Ensemble.Editor.TimelineMGR._clipIndex[Ensemble.Editor.TimelineMGR._clipIndexPosition].renderList.indexOf(targetClip) > -1) needFrame = true;
                 }
             }
 
             if (!found) {
-                needFrame = true;
-                Ensemble.Editor.TimelineMGR.getClipById(clipId).selected = true;
+                let targetClip = Ensemble.Editor.TimelineMGR.getClipById(clipId);
+                targetClip.selected = true;
+                if (targetClip.isRenderable() && Ensemble.Editor.TimelineMGR._clipIndex[Ensemble.Editor.TimelineMGR._clipIndexPosition].renderList.indexOf(targetClip) > -1) needFrame = true;
                 $("#" + Ensemble.Editor.TimelineMGR._buildClipDOMId(clipId)).addClass("timeline-clip--selected");
                 console.log("Selected clip " + clipId + ".");
             }
@@ -96,7 +98,7 @@
                 clip.hovering = true;
                 this.hovering.push(clip);
                 $("#" + Ensemble.Editor.TimelineMGR._buildClipDOMId(clipId)).addClass("timeline-clip--hovering");
-                Ensemble.Editor.Renderer.requestFrame();
+                if (clip.isRenderable() && Ensemble.Editor.TimelineMGR._clipIndex[Ensemble.Editor.TimelineMGR._clipIndexPosition].renderList.indexOf(clip) > -1) Ensemble.Editor.Renderer.requestFrame();
             }
         },
 
@@ -118,7 +120,7 @@
                 let clip = this.hovering.splice(clipIndex, 1)[0];
                 clip.hovering = false;
                 $("#" + Ensemble.Editor.TimelineMGR._buildClipDOMId(clipId)).removeClass("timeline-clip--hovering");
-                Ensemble.Editor.Renderer.requestFrame();
+                if (clip.isRenderable() && Ensemble.Editor.TimelineMGR._clipIndex[Ensemble.Editor.TimelineMGR._clipIndexPosition].renderList.indexOf(clip) > -1) Ensemble.Editor.Renderer.requestFrame();
             }
         },
 
@@ -145,15 +147,17 @@
                     found = true;
                 }
                 if (this.hovering[i] != clipId) {
-                    Ensemble.Editor.TimelineMGR.getClipById(this.hovering[i]).hovering = false;
+                    let targetClip = Ensemble.Editor.TimelineMGR.getClipById(this.hovering[i]);
+                    targetClip.hovering = false;
                     $("#" + Ensemble.Editor.TimelineMGR._buildClipDOMId(this.hovering[i])).removeClass("timeline-clip--hovering");
-                    needFrame = true;
+                    if (targetClip.isRenderable()) needFrame = true;
                 }
             }
 
             if (!found) {
-                needFrame = true;
-                Ensemble.Editor.TimelineMGR.getClipById(clipId).hovering = true;
+                let targetClip = Ensemble.Editor.TimelineMGR.getClipById(clipId);
+                targetClip.hovering = true;
+                if (targetClip.isRenderable()) needFrame = true;
                 $("#" + Ensemble.Editor.TimelineMGR._buildClipDOMId(clipId)).addClass("timeline-clip--hovering");
             }
             this.hovering = [];

--- a/Ensemble of One/js/editor/timer.js
+++ b/Ensemble of One/js/editor/timer.js
@@ -45,17 +45,24 @@ function processTime () {
 
 function checkBreakpoints() {
     /// <summary>Checks to see if the rendering/playback breakpoint has changed.</summary>
-    for (let i = breakpoints.length - 1; i > -1; i--) {
-        if (lastTime > breakpoints[i]) {
-            // i is the current position in the index
-            if (i != position) {
-                // switching to a new position.
-                position = i;
-                console.log("New position: " + position + ", time: " + lastTime);
-                postMessage({ type: "newIndexPosition", contents: position });
+    let oldPosition = position;
+    if (lastTime > 0) {
+        for (let i = breakpoints.length - 1; i > -1; i--) {
+            if (lastTime > breakpoints[i]) {
+                // i is the current position in the index
+                if (i != position) {
+                    // switching to a new position.
+                    position = i;
+                }
+                break;
             }
-            break;
         }
+    }
+    else position = 0;
+
+    if (position != oldPosition) {
+        console.log("New position: " + position + ", time: " + lastTime);
+        postMessage({ type: "newIndexPosition", contents: position });
     }
 }
 

--- a/Ensemble of One/js/events/action.js
+++ b/Ensemble of One/js/events/action.js
@@ -224,11 +224,13 @@
                                 break;
                         }
 
-                        let dimensions = Ensemble.Editor.Renderer.generateClipInitialPosition(player.videoWidth, player.videoHeight);
-                        clip.width = player.width = dimensions.width;
-                        clip.height = player.height = dimensions.height;
-                        clip.xcoord = dimensions.xcoord;
-                        clip.ycoord = dimensions.ycoord;
+                        if (clip.isRenderable()) {
+                            let dimensions = Ensemble.Editor.Renderer.generateClipInitialPosition(player.videoWidth, player.videoHeight);
+                            clip.width = player.width = dimensions.width;
+                            clip.height = player.height = dimensions.height;
+                            clip.xcoord = dimensions.xcoord;
+                            clip.ycoord = dimensions.ycoord;
+                        }
                     }
                     clip.setPlayer(player);
                     Ensemble.Editor.TimelineMGR.addClipToTrack(clip, destinationTrack, destinationTime);


### PR DESCRIPTION
Changes include:
- Closed #70. Users can now click any location in the Timeline ruler to
  instantly seek to that position.
- Closed #55. Audio files can now be imported into user projects, and do
  not render to the Canvas.
- Various updates to **Ensemble.Editor.Renderer**,
  **Ensemble.Editor.SelectionMGR**, and **Ensemble.Editor.TimelineMGR** to
  properly support audio files.
- Updates to **Ensemble.Editor.SelectionMGR** to increase efficiency and
  decrease the likelihood that a dead frame will be requested (a frame in
  which nothing has changed).
- Closed #20. Added a new case to timer.js to handle "seek to zero"
  situations.
- Closed #25. Mostly just considering it closed, since it's been
  effectively closed and revised in previous commits. Take note of
  outstanding bug #60.
- Updated **Ensemble.Editor.TimelineMGR** to separate renderable clips from
  non-renderable clips in the playback index. This helps prevent
  unnecessary rendering passes and was necessary for adding audio file
  support.
